### PR TITLE
Add `.gitattributes` to force `lf` line endings for all the users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=lf
+*.ts text eol=lf


### PR DESCRIPTION
This will solve the issue for Windows users, who run `check-integrity.js` and has all the files "out of sync" because of `crlf` line endings on Windows after checkout