### PR TITLE
Add `.editorconfig` to force PHPStorm/VSCode to have 2 spaces instead of 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+end_of_line = lf
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.ts]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Add `.editorconfig` to force PHPStorm/VSCode to have 2 spaces instead of 4

I am a WebStorm user, after checking out the code and starting adding my changed, WebStorm by default uses 4 spaces as this is my defaults.

However, the code in this repository uses 2 spaces, and the result code (my and existing) is mixed.

In order to unify it, there is a comcept of `.editorconfig`.

This PR adds this meta file which is recognized by VSCode/WebStorm and other editors.