### PR TITLE
Add database.db to ignore watch in dev:start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:ts": "tsc",
     "watch:ts": "tsc -w",
     "dev": "npm run build:ts && concurrently -k -p \"[{name}]\" -n \"TypeScript,App\" -c \"yellow.bold,cyan.bold\" \"npm:watch:ts\" \"npm:dev:start\"",
-    "dev:start": "fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js"
+    "dev:start": "fastify start --ignore-watch=\".ts$ database.db\" -w -l info -P dist/app.js"
   },
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
This will resolve the issue of the server restarting in development mode during mutations.